### PR TITLE
fix(tests): resolve 6 integration test failures

### DIFF
--- a/tests/integration/test_cli_base.py
+++ b/tests/integration/test_cli_base.py
@@ -48,17 +48,23 @@ def strip_ansi_codes(text: str) -> str:
     return ansi_escape.sub('', text)
 
 
+def normalize_output(text: str) -> str:
+    """Strip ANSI codes and normalize whitespace (collapse newlines and spaces into single spaces)."""
+    text = strip_ansi_codes(text)
+    return re.sub(r'\s+', ' ', text).strip()
+
+
 def verify_cli_success(result: CLICommandResult, expected_output_contains: Optional[str] = None):
     assert result.exit_code == 0, f"Command failed with exit code {result.exit_code}. stderr: {result.stderr}"
     if expected_output_contains:
-        clean_stdout = strip_ansi_codes(result.stdout)
+        clean_stdout = normalize_output(result.stdout)
         assert expected_output_contains in clean_stdout, f"Expected '{expected_output_contains}' in output: {clean_stdout}"
 
 
 def verify_cli_failure(result: CLICommandResult, expected_exit_code: int = 1, expected_error_contains: Optional[str] = None):
     assert result.exit_code == expected_exit_code, f"Expected exit code {expected_exit_code}, got {result.exit_code}"
     if expected_error_contains:
-        combined_output = result.stderr + result.stdout
+        combined_output = normalize_output(result.stderr + result.stdout)
         assert expected_error_contains in combined_output, f"Expected '{expected_error_contains}' in error output: {combined_output}"
 
 

--- a/tests/integration/test_drift_type_command.py
+++ b/tests/integration/test_drift_type_command.py
@@ -74,6 +74,7 @@ def test_expect_substring_case_insensitive_false():
 
 
 def test_text_similarity_high_score():
+    pytest.importorskip("sentence_transformers", reason="sentence-transformers package required")
     result = execute_cli_command([
         "promptdrifter", CLICommands.TEST_DRIFT_TYPE,
         DriftTypes.TEXT_SIMILARITY, "The quick brown fox", "The quick brown fox"
@@ -83,6 +84,7 @@ def test_text_similarity_high_score():
 
 
 def test_text_similarity_medium_score():
+    pytest.importorskip("sentence_transformers", reason="sentence-transformers package required")
     result = execute_cli_command([
         "promptdrifter", CLICommands.TEST_DRIFT_TYPE,
         DriftTypes.TEXT_SIMILARITY, "The quick brown fox", "The fast brown fox"
@@ -92,6 +94,7 @@ def test_text_similarity_medium_score():
 
 
 def test_text_similarity_low_score():
+    pytest.importorskip("sentence_transformers", reason="sentence-transformers package required")
     result = execute_cli_command([
         "promptdrifter", CLICommands.TEST_DRIFT_TYPE,
         DriftTypes.TEXT_SIMILARITY, "The quick brown fox", "Completely different text"

--- a/tests/integration/test_general_commands.py
+++ b/tests/integration/test_general_commands.py
@@ -1,4 +1,4 @@
-from .test_cli_base import execute_cli_command, verify_cli_success
+from .test_cli_base import execute_cli_command, normalize_output, verify_cli_success
 
 
 def test_version_flag_shows_version():
@@ -19,7 +19,11 @@ def test_main_help_command():
 
 def test_no_args_shows_help():
     result = execute_cli_command(["promptdrifter"])
-    verify_cli_success(result, "Usage:")
+    assert result.exit_code in (0, 2), (
+        f"Expected exit code 0 or 2, got {result.exit_code}. stderr: {result.stderr}"
+    )
+    clean_output = normalize_output(result.stdout + result.stderr)
+    assert "Usage:" in clean_output, f"Expected 'Usage:' in output: {clean_output}"
 
 
 def test_invalid_command():


### PR DESCRIPTION
- Add normalize_output helper to collapse Rich console line wrapping in
  subprocess output, fixing init command tests that broke on long paths
- Skip text_similarity tests when sentence-transformers is not installed
  (CI installs it explicitly; local environments may not have it)
- Accept exit code 2 for no-args help test (Typer's no_args_is_help
  convention)

https://claude.ai/code/session_01KQwwEF5wzagSvnQxNMGwi5